### PR TITLE
Add URLs to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,8 @@ Authors@R: c(
            email = 'hwanistic@gmail.com'))
 Description: Full screen and partial loading screens for 'Shiny' with spinners, progress bars, and notifications.
 License: MIT + file LICENSE
+URL: https://waiter.john-coene.com/, https://github.com/JohnCoene/waiter
+BugReports: https://github.com/JohnCoene/waiter/issues
 Encoding: UTF-8
 LazyData: true
 Imports:


### PR DESCRIPTION
Adds `waiter` page and GitHub repo and issues to DESCRIPTION to make it easier to find the awesome documentation and page you've put together for the package!