### PR TITLE
Hostess infinite implementation

### DIFF
--- a/R/hostess.R
+++ b/R/hostess.R
@@ -37,7 +37,7 @@ hostess_init <- function(id = "hostess"){
   if(id == "hostess")
     warning("Using default `id`", call. = FALSE)
 
-  .Deprecated("Hostess", package = "waiter", "Deprecated in favour of R6Class <Waitress>")
+  .Deprecated("Hostess", package = "waiter", "Deprecated in favour of R6Class <Hostess>")
 
   session <- shiny::getDefaultReactiveDomain()
   .check_session(session)
@@ -51,7 +51,7 @@ hostess_set <- function(id = "hostess", value){
   if(id == "hostess")
     warning("Using default `id`", call. = FALSE)
 
-  .Deprecated("Hostess", package = "waiter", "Deprecated in favour of R6Class <Waitress>")
+  .Deprecated("Hostess", package = "waiter", "Deprecated in favour of R6Class <Hostess>")
 
   session <- shiny::getDefaultReactiveDomain()
   .check_session(session)

--- a/R/hostess.R
+++ b/R/hostess.R
@@ -183,6 +183,23 @@ Hostess <- R6::R6Class(
       invisible(self)
     },
 #' @details
+#' Close the hostess
+#' 
+#' @examples
+#' \dontrun{Waitress$new("#plot")$close()}
+    close = function() {
+      # get id
+      opts <- list(infinite = private$.infinite)
+      # reset the started
+      private$.started <- FALSE
+      # loop for the ids
+      for(i in 1:length(private$.id)){
+        opts$id <- private$.id[i]
+        private$.session$sendCustomMessage("hostess-end", opts)
+      }
+      invisible(self)
+    },
+#' @details
 #' Create a hostess loading bar.
 #' @param value Value to set, between \code{0} and \code{100}.
 #' @param preset A loading bar preset, see section below.

--- a/R/hostess.R
+++ b/R/hostess.R
@@ -72,10 +72,13 @@ Hostess <- R6::R6Class(
 #' @param min,max Minimum and maximum representing the starting and ending
 #' points of the progress bar.
 #' @param n Number of loaders to generate.
+#' @param infinite Set to \code{TRUE} to create a never ending loading bar, ideal
+#' when you cannot compute increments or assess the time it might take before the
+#' loading bar should be removed.
 #' 
 #' @examples
 #' \dontrun{Hostess$new()}
-    initialize = function(id = NULL, min = 0, max = 100, n = 1){
+    initialize = function(id = NULL, min = 0, max = 100, n = 1, infinite = FALSE){
       if(is.null(id))
         id <- .random_name()
 
@@ -88,6 +91,12 @@ Hostess <- R6::R6Class(
         id2 <- sapply(1:n, function(x) .random_name())
         id <- c(id, id2) 
       }
+      
+      # override min/max if infinite
+      if (infinite) {
+        min <- 0
+        max <- 100
+      }
 
       session <- shiny::getDefaultReactiveDomain()
       .check_session(session)
@@ -95,13 +104,16 @@ Hostess <- R6::R6Class(
       private$.id <- id
       private$.min <- min
       private$.max <- max
+      private$.infinite <- infinite
     },
 #' @details
 #' Start the hostess
     start = function(){
       private$.started <- TRUE
+      opts <- list(infinite = private$.infinite)
       for(i in 1:length(private$.id)){
-        private$.session$sendCustomMessage("hostess-init", list(id = private$.id[i]))
+        opts$id <- private$.id[i]
+        private$.session$sendCustomMessage("hostess-init", opts)
       }
       invisible(self)
     },
@@ -304,7 +316,8 @@ Hostess <- R6::R6Class(
     .max = 100,
     .current_value = 0,
     .loader = NULL,
-    .is_notification = FALSE
+    .is_notification = FALSE,
+    .infinite = FALSE
   )
 )
 

--- a/R/hostess.R
+++ b/R/hostess.R
@@ -302,7 +302,7 @@ Hostess <- R6::R6Class(
         position = position,
         background_color = background_color,
         text_color = text_color,
-        infinite = priveate$.infinite
+        infinite = private$.infinite
       )
 
       private$.session$sendCustomMessage("hostess-notify", opts)

--- a/R/hostess.R
+++ b/R/hostess.R
@@ -301,7 +301,8 @@ Hostess <- R6::R6Class(
         id = private$.id, 
         position = position,
         background_color = background_color,
-        text_color = text_color
+        text_color = text_color,
+        infinite = priveate$.infinite
       )
 
       private$.session$sendCustomMessage("hostess-notify", opts)

--- a/inst/assets/hostess/custom.js
+++ b/inst/assets/hostess/custom.js
@@ -9,7 +9,7 @@ Shiny.addCustomMessageHandler('hostess-init', function(opts) {
         inc = 0,
         end = 100;
 
-    intervals[opts.name] = setInterval(function(){
+    intervals[opts.id] = setInterval(function(){
       inc = ((end - value) / (end + value));
       value = Math.round((value + inc + Number.EPSILON) * 1000) / 1000
       hostesses[opts.id].set(value);
@@ -58,12 +58,22 @@ Shiny.addCustomMessageHandler('hostess-notify', function(opts) {
         inc = 0,
         end = 100;
 
-    intervals[opts.name] = setInterval(function(){
+    intervals[opts.id] = setInterval(function(){
       inc = ((end - value) / (end + value));
       value = Math.round((value + inc + Number.EPSILON) * 1000) / 1000
       hostesses[opts.id].set(value);
     }, 350);
   }
+});
+
+Shiny.addCustomMessageHandler('hostess-end', function(opts) {
+  var bar = document.getElementById(opts.id);
+  
+  if(opts.infinite)
+    clearInterval(intervals[opts.id]);
+  
+  if(bar != undefined)
+    bar.remove();
 });
 
 function position_to_coords(position){

--- a/inst/assets/hostess/custom.js
+++ b/inst/assets/hostess/custom.js
@@ -1,7 +1,20 @@
 var hostesses = [];
+var intervals = [];
 
 Shiny.addCustomMessageHandler('hostess-init', function(opts) {
   hostesses[opts.id] = new ldBar("#" + opts.id);
+  
+  if(opts.infinite){
+    var value = 0,
+        inc = 0,
+        end = 100;
+
+    intervals[opts.name] = setInterval(function(){
+      inc = ((end - value) / (end + value));
+      value = Math.round((value + inc + Number.EPSILON) * 1000) / 1000
+      hostesses[opts.id].set(value);
+    }, 350);
+  }
 });
 
 Shiny.addCustomMessageHandler('hostess-set', function(opts) {

--- a/inst/assets/hostess/custom.js
+++ b/inst/assets/hostess/custom.js
@@ -69,11 +69,17 @@ Shiny.addCustomMessageHandler('hostess-notify', function(opts) {
 Shiny.addCustomMessageHandler('hostess-end', function(opts) {
   var bar = document.getElementById(opts.id);
   
-  if(opts.infinite)
+  if(opts.infinite){
     clearInterval(intervals[opts.id]);
+    hostesses[opts.id].set(95);
+  }
+    
   
   if(bar != undefined)
-    bar.remove();
+    // small delay to allow the loading bar to end
+    setTimeout(function(){
+      bar.remove();
+    }, 350)
 });
 
 function position_to_coords(position){

--- a/inst/assets/hostess/custom.js
+++ b/inst/assets/hostess/custom.js
@@ -52,6 +52,18 @@ Shiny.addCustomMessageHandler('hostess-notify', function(opts) {
   document.body.appendChild(notification);
 
   hostesses[opts.id] = new ldBar("#" + opts.id);
+  
+  if(opts.infinite){
+    var value = 0,
+        inc = 0,
+        end = 100;
+
+    intervals[opts.name] = setInterval(function(){
+      inc = ((end - value) / (end + value));
+      value = Math.round((value + inc + Number.EPSILON) * 1000) / 1000
+      hostesses[opts.id].set(value);
+    }, 350);
+  }
 });
 
 function position_to_coords(position){

--- a/man/hostess.Rd
+++ b/man/hostess.Rd
@@ -43,6 +43,12 @@ Add hostess dependencies.
 \dontrun{Hostess$new()$inc(10)}
 
 ## ------------------------------------------------
+## Method `Hostess$close`
+## ------------------------------------------------
+
+\dontrun{Waitress$new("#plot")$close()}
+
+## ------------------------------------------------
 ## Method `Hostess$get_loader`
 ## ------------------------------------------------
 
@@ -71,6 +77,7 @@ Hostess$new()$set_loader(loader)
 \item \href{#method-print}{\code{Hostess$print()}}
 \item \href{#method-set}{\code{Hostess$set()}}
 \item \href{#method-inc}{\code{Hostess$inc()}}
+\item \href{#method-close}{\code{Hostess$close()}}
 \item \href{#method-get_loader}{\code{Hostess$get_loader()}}
 \item \href{#method-set_loader}{\code{Hostess$set_loader()}}
 \item \href{#method-notify}{\code{Hostess$notify()}}
@@ -82,7 +89,7 @@ Hostess$new()$set_loader(loader)
 \if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Hostess$new(id = NULL, min = 0, max = 100, n = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Hostess$new(id = NULL, min = 0, max = 100, n = 1, infinite = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -95,6 +102,10 @@ the \code{loader} method you may leave this \code{NULL}.}
 points of the progress bar.}
 
 \item{\code{n}}{Number of loaders to generate.}
+
+\item{\code{infinite}}{Set to \code{TRUE} to create a never ending loading bar, ideal
+when you cannot compute increments or assess the time it might take before the
+loading bar should be removed.}
 }
 \if{html}{\out{</div>}}
 }
@@ -187,6 +198,27 @@ Increase the hostess loading bar.
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{\dontrun{Hostess$new()$inc(10)}
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-close"></a>}}
+\if{latex}{\out{\hypertarget{method-close}{}}}
+\subsection{Method \code{close()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Hostess$close()}\if{html}{\out{</div>}}
+}
+
+\subsection{Details}{
+Close the hostess
+}
+
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{Waitress$new("#plot")$close()}
 }
 \if{html}{\out{</div>}}
 


### PR DESCRIPTION
Related to issue: #65 

I have a working version with `infinite` capability for Hostess.
I had to create a `$close()` method similiar to the `waitress` one, to be able to send an end signal to the `ldBar` element, as in the original code the bar was only closed when reaching 100%.
This means that when using the infinite switch, the `Hostess` object must be closed when the calculations end:

```
### waiter + hostess normal
library(shiny)
library(waiter)

ui <- fluidPage(
  use_waiter(),
  use_hostess(),
  waiter_show_on_load(
    color = "#f7fff7",
    hostess_loader(
      "loader", 
      preset = "circle", 
      text_color = "black",
      class = "label-center",
      center_page = TRUE
    )
  )
)

server <- function(input, output){
  hostess <- Hostess$new("loader", infinite = TRUE)
  
  # for(i in 1:10){
  #   Sys.sleep(runif(1) / 2)
  #   hostess$set(i * 10)
  # }
  hostess$start()
  Sys.sleep(5)
  hostess$close()
  waiter_hide()
}

shinyApp(ui, server)

```

I have also updated the documentation in `docs/hostess.md` to add some examples using infinite, and ran all the hostess examples in the docs to check they are still working with the new changes. All seems ok, but maybe something is missed, let me know if it is ok.