### PR TITLE
fix: Autowaiter bug when called multiple times

### DIFF
--- a/R/waiter.R
+++ b/R/waiter.R
@@ -772,9 +772,8 @@ autoWaiter <- function(
   ids <- paste0("['", paste0(id, collapse = "','"), "']")
 
   script <- sprintf(
-    "let auto = %s;
-    $(document).on('shiny:recalculating', function(event) {
-
+    "$(document).on('shiny:recalculating', function(event) {
+      const auto = %s;
       if(!auto)
         if(!%s.includes(event.target.id))
           return ;


### PR DESCRIPTION
Closes #139

Thanks for this awesome package! 

## Changes in this PR
In the previous implementation the variable `auto` was being declared in the global scope. This was causing that multiple calls to the `autoWaiter` function were attempting to redeclare the function thus the error message mentioned by @daattali: `Uncaught SyntaxError: Identifier 'auto' has already been declared`

By declaring the `auto` variable within the scope of the callback when listening to `shiny:recalculating` we avoid this problem

## How to test 

Here we have an example shiny app (see below) that uses two modules with `autoWaiter` pointing to an specific id. In this example you'll see that the first autowaiter called will work as expected while the second one won't (see gif)
![Peek 2023-09-22 13-35](https://github.com/JohnCoene/waiter/assets/25372718/849670d1-3f60-4d59-8041-d1b3c9861ffb)

With the changes in this PR looks like this
![Peek 2023-09-22 13-36](https://github.com/JohnCoene/waiter/assets/25372718/09398c1a-e077-406a-ba6f-bc49ad223def)

### Example app

```R
library(shiny)
library(waiter)

# Define Module A
module_a_ui <- function(id) {
  ns <- NS(id)
  fluidPage(
    autoWaiter(id = ns("plot")),
    sidebarLayout(
      sidebarPanel(
        actionButton(ns("btn_submit"), "Plot")
      ),
      mainPanel(
        plotOutput(ns("plot"))
      )
    )
  )
}

module_a_server <- function(id) {
  moduleServer(id, function(input, output, session) {
    observeEvent(input$btn_submit, {
      output$plot <- renderPlot({
        Sys.sleep(1)
        plot(iris)
      })
    })
  })
}

# Define Module B
module_b_ui <- function(id) {
  ns <- NS(id)
  fluidPage(
    autoWaiter(id = ns("plot")),
    sidebarLayout(
      sidebarPanel(
        actionButton(ns("btn_submit"), "Plot")
      ),
      mainPanel(
        plotOutput(ns("plot"))
      )
    )
  )
}

module_b_server <- function(id) {
  moduleServer(id, function(input, output, session) {
    observeEvent(input$btn_submit, {
      output$plot <- renderPlot({
        Sys.sleep(1)
        plot(iris)
      })
    })
  })
}

# Main Shiny App
ui <- fluidPage(
  tabsetPanel(
    tabPanel("Module A", module_a_ui("moduleA")),
    tabPanel("Module B", module_b_ui("moduleB"))
  )
)

server <- function(input, output, session) {
  module_a_server("moduleA")
  module_b_server("moduleB")
}

shinyApp(ui, server)

```

