### PR TITLE
Update combos.md with note about using local Lottie json files

### DIFF
--- a/docs/waiter/combos.md
+++ b/docs/waiter/combos.md
@@ -49,10 +49,48 @@ Second, find an animation you like and click "Generate link" (bottom right).
 
 ![](_assets/img/lottie-gen.png)
 
-Finnaly, obtain the JSON link and use it in the `lottie` function 
+Finally, obtain the JSON link and use it in the `lottie` function 
 as done in the example above.
 
 ![](_assets/img/lottie-link.png)
+
+
+| __Note:__  Using ***Local*** Lottie Files |
+| :--- |
+| You may encounter issues if trying to generate a lottie animation using a json file stored in the local Shiny `www` static resources folder. A simple workaround is to add this folder (or subfolder) as a [resource path](https://rdrr.io/cran/shiny/man/resourcePaths.html). Doing so enables the Shiny web server to retrieve the lottie json file at the top level when sourced by functions in scripts stored elsewhere in the project folder tree. The example below demonstrates how a local lottie file (__"MyLocalLottieFile.json"__) can be used with `waiterPreloader` to animate a full page loading screen. |
+```r
+library(shiny)
+library(waiter)
+
+# Check to see if 'LottieFiles' is already a resource path variable.
+# If not, it is added.
+if (!("LottieFiles" %in% names(resourcePaths()))) {
+  addResourcePath("LottieFiles","./www/lottie/")
+}
+
+ui <- fluidPage(
+  useWaiter(),
+  useLottie(),
+  
+  # A local lottie file (MyLocalLottieFile.json) is sourced here using 
+  # the resource path variable (LottieFiles) declared above.
+  waiterPreloader(
+    html = lottie('LottieFiles/MyLocalLottieFile.json')
+    ),
+  h1("The title of the app")
+)
+
+server <- function(input, output, session){
+  Sys.sleep(3) 
+  waiter_hide()
+}
+
+shinyApp(ui, server)
+```
+
+
+
+
 
 ## With Hostess
 


### PR DESCRIPTION
#### TL;DR
The `combos.md` docs file has been edited to describe how users can source local lottie files with `waiter`.

#### Why? 💡 
Locally saved lottie json files can fail to render with `waiter` when sourced via relative filepaths to the Shiny static resources folder (`www`).
This issue also occurs with [`shinyLottie`](https://camhowitt.github.io/shinyLottie/index.html) where @camhowitt  includes this [note](https://camhowitt.github.io/shinyLottie/reference/lottie_animation.html#note) recommending users to add the static resources folder (`www`) as a resource path variable.
Doing this means functions can source local lottie json files regardless of where the script sits in the project folder tree.

#### What 📝 
I have tested this workaround with `waiter` and it works as a simple fix (see code below).
To help `waiter` users, I have edited the `combos.md` where lottie use cases are described.
This edit includes:
1. A note highlighting the issue and an explanation of the solution,
2. Example code (same as below) showing users how a local lottie json file can be combined with `waiterPreloader`.

I appreciate that the lottie feature is still in dev, but this note may benefit users nonetheless 🙂 
Hope it helps 👍🏼 
Matt

-------------------

On a side note, the `waiter` package is phenomenal!  🚀 
@JohnCoene, you've done amazing work and it's greatly appreciated 🙌🏼 🙌🏼 

-------------------
```r
library(shiny)
library(waiter)

# Check to see if 'LottieFiles' is already a resource path variable.
# If not, it is added.
if (!("LottieFiles" %in% names(resourcePaths()))) {
  addResourcePath("LottieFiles","./www/lottie/")
}

ui <- fluidPage(
  useWaiter(),
  useLottie(),
  
  # A local lottie file (MyLocalLottieFile.json) is sourced here using 
  # the resource path variable (LottieFiles) declared above.
  waiterPreloader(
    html = lottie('LottieFiles/MyLocalLottieFile.json')
    ),
  h1("The title of the app")
)

server <- function(input, output, session){
  Sys.sleep(3) 
  waiter_hide()
}

shinyApp(ui, server)
```